### PR TITLE
fix: add extra uuid check for ProTimers

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -914,6 +914,7 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 				const thisProTimerState = instance.propresenterStateStore.proTimers.find(
 					(proTimerState) =>
 						proTimerState.id.uuid == timerID ||
+						proTimerState.id.uuid.replace(/-/g, '') == timerID ||
 						proTimerState.id.name == timerID ||
 						proTimerState.id.index == parseInt(timerID)
 				)

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -511,7 +511,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 				return (
 					instance.propresenterStateStore.proTimers.find(
 						(proTimer) =>
-							proTimer.id.uuid == timer_id || proTimer.id.name == timer_id || proTimer.id.index == parseInt(timer_id)
+							proTimer.id.uuid == timer_id || proTimerState.id.uuid.replace(/-/g, '') == timerID || proTimer.id.name == timer_id || proTimer.id.index == parseInt(timer_id)
 					)?.state == feedback.options.timer_state
 				)
 			},


### PR DESCRIPTION
When looking for ProPresenter Timers from state it will also check for the UUID4 without a dash ('-') as it is shown in the module variable names.
